### PR TITLE
fix: Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.1', '8.2', '8.3', '8.4']
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         exclude:
           - php: '8.1'
             laravel: '11.*'
           - php: '8.1'
             laravel: '12.*'
+          - php: '8.1'
+            laravel: '13.*'
+          - php: '8.2'
+            laravel: '13.*'
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,4 +67,4 @@ vendor/bin/phpunit --coverage-html coverage/
 
 ## CI
 
-GitHub Actions runs PHPUnit across PHP 8.1–8.4 and Laravel 10–12 (excluding PHP 8.1 + Laravel 11/12).
+GitHub Actions runs PHPUnit across PHP 8.1–8.4 and Laravel 10–13 (excluding PHP 8.1 + Laravel 11/12/13, PHP 8.2 + Laravel 13).

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
   },
   "require": {
     "php": "^8.1|^8.2|^8.3|^8.4",
-    "illuminate/support": "^10.0|^11.0|^12.0",
-    "illuminate/contracts": "^10.0|^11.0|^12.0",
-    "symfony/process": "^6.0|^7.0"
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+    "symfony/process": "^6.0|^7.0|^8.0"
   },
   "require-dev": {
-    "orchestra/testbench": "^8.0|^9.0|^10.0",
+    "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
     "phpunit/phpunit": "^10.0|^11.0",
     "mockery/mockery": "^1.6"
   },


### PR DESCRIPTION
## What

Add Laravel 13 support

## Why

Laravel 13 is out

## How

Just pump up some package version

## Testing

<!-- How did you test this? -->

- [x] All tests pass: `vendor/bin/phpunit`